### PR TITLE
Update calendar defaults and footer

### DIFF
--- a/calendar/app.js
+++ b/calendar/app.js
@@ -127,7 +127,7 @@ const eventsData = [
 
 // Global variables
 let calendar;
-let currentView = 'month';
+let currentView = 'list';
 let filteredEvents = [...eventsData];
 
 // DOM elements
@@ -152,6 +152,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeEventFilter();
     initializeKeyboardNavigation();
     populateListView();
+    switchToListView();
     
     // Hide loading overlay after short delay to allow calendar render
     setTimeout(() => {

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     <section id="calendar" class="section fade-section">
       <div class="container">
         <h2 class="section-title">Calendar</h2>
+        <div class="open-fullscreen"><a href="/calendar/index.html" target="_blank" class="btn btn--outline">Open Full Screen</a></div>
         <iframe src="/calendar/index.html" width="100%" height="800" loading="lazy"></iframe>
       </div>
     </section>
@@ -147,6 +148,7 @@
         <div class="events-grid" id="eventsGrid">
           <!-- Events will be populated by JavaScript -->
         </div>
+        <div class="open-fullscreen"><a href="/calendar/index.html" target="_blank" class="btn btn--outline">Open Full Screen</a></div>
         <iframe src="/calendar/index.html" width="100%" height="800" loading="lazy"></iframe>
       </div>
     </section>
@@ -202,15 +204,16 @@
                 <div><h4 class="font-bold text-lg mb-4 text-gray-900">Join Our Newsletter</h4><form onsubmit="return false;"><div class="flex"><input type="email" class="w-full rounded-l-md px-3 py-2 border border-gray-300 text-gray-800" placeholder="your.email@example.com"><button type="submit" class="bg-teal-600 text-white px-4 py-2 rounded-r-md hover:bg-teal-700">&rarr;</button></div></form><div class="flex space-x-4 mt-4"><a href="https://www.facebook.com/KokomoArtAssociation/?fref=ts" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-facebook-square"></i></a><a href="https://www.instagram.com/kokomoartassociation/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-instagram-square"></i></a></div></div>
             </div>
             <div class="footer-sponsor-section">
-                <h4 class="font-bold text-lg mb-6 text-center text-gray-700">Our Valued Sponsors</h4>
-                <div class="flex flex-wrap justify-center items-center gap-8 footer-sponsors">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
+                <div class="container sponsor-container">
+                    <div class="flex flex-wrap justify-center items-center gap-8 footer-sponsors">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
+                    </div>
                 </div>
             </div>
             <div class="border-t border-gray-200 mt-8 pt-6 text-center text-gray-600"><p>&copy; <span id="year"></span> Kokomo Art Association. All Rights Reserved.</p></div>

--- a/style.css
+++ b/style.css
@@ -169,6 +169,11 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.open-fullscreen {
+  text-align: right;
+  margin-bottom: var(--space-16);
+}
+
 @media (max-width: 640px) {
   .footer-sponsors img {
     max-width: 90px;


### PR DESCRIPTION
## Summary
- default calendar view is now list view
- add open full screen buttons in calendar sections
- remove sponsor heading and wrap logos in a new container
- style open fullscreen link

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687bebf5e83083289eb58778144bd67a