### PR TITLE
Add calendar toggle and links

### DIFF
--- a/app.js
+++ b/app.js
@@ -213,8 +213,182 @@ const appData = {
   ]
 };
 
+// Structured event data for calendar links
+const eventsCalendarData = [
+  {
+    id: 'splash-watercolor',
+    title: 'Splash of Watercolor Exhibit',
+    start: '2025-07-01',
+    end: '2025-07-30',
+    allDay: true,
+    location: 'Kokomo Art Center, 525 W Ricketts St',
+    description:
+      'Delicately beautiful watercolor artworks by Jennie Moore, Judy Arthur, Cissie Seidman, and Dixie Bennett.'
+  },
+  {
+    id: 'guest-artist-bass',
+    title: 'Guest Artist Reception: Brandon C. Bass',
+    start: '2025-07-12T12:00:00',
+    end: '2025-07-12T15:00:00',
+    location: 'Artworks Gallery, 210 N Main St',
+    description:
+      'Free reception featuring portraits, military subjects, pets & landscapes by Brandon C. Bass. Light refreshments provided.'
+  },
+  {
+    id: 'first-friday-aug',
+    title: "First Friday 'Get Schooled!'",
+    start: '2025-08-01T17:30:00',
+    end: '2025-08-01T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Back-to-school themed art demos and activities. KAA hosts open house in Artworks Gallery.'
+  },
+  {
+    id: 'first-friday-sep',
+    title: "First Friday 'Art Walk'",
+    start: '2025-09-05T17:30:00',
+    end: '2025-09-05T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Monthly arts-driven street festival with gallery programming and community art activities.'
+  },
+  {
+    id: 'first-friday-oct',
+    title: "First Friday 'Masquerade'",
+    start: '2025-10-03T17:30:00',
+    end: '2025-10-03T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Halloween-themed First Friday with masquerade activities and special gallery exhibitions.'
+  },
+  {
+    id: 'first-friday-nov',
+    title: "First Friday 'Shop & Stroll'",
+    start: '2025-11-07T17:30:00',
+    end: '2025-11-07T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Holiday shopping-themed First Friday with local artists showcasing gift-worthy works.'
+  },
+  {
+    id: 'holiday-bazaar',
+    title: 'Holiday Bazaar',
+    start: '2025-11-01',
+    end: '2025-12-23',
+    allDay: true,
+    location: 'Artworks Gallery, 210 N Main St',
+    description:
+      'Extended holiday market featuring local artists and craftspeople. Open Mon-Sat 12-4 PM with extended hours on First Fridays.'
+  },
+  {
+    id: 'first-friday-dec',
+    title: "First Friday 'Ugly Sweater'",
+    start: '2025-12-05T17:30:00',
+    end: '2025-12-05T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Holiday-themed First Friday with ugly sweater contest and festive art activities.'
+  },
+  {
+    id: 'spring-art-show',
+    title: '97th Annual Spring Art Show',
+    start: '2025-05-22',
+    end: '2025-06-01',
+    allDay: true,
+    location: 'Kokomo Art Center, 525 W Ricketts St',
+    description:
+      'Annual juried showcase featuring the best of local and regional artists. Closing reception June 1 at 2 PM.'
+  },
+  {
+    id: 'recycled-art-show',
+    title: 'Recycled Art Show',
+    start: '2025-03-07',
+    end: '2025-04-25',
+    allDay: true,
+    location: 'Artworks Gallery, 210 N Main St',
+    description:
+      'Juried exhibition featuring works created with 80% or more recycled materials. Awards reception April 4.'
+  },
+  {
+    id: 'junk-journal-workshop',
+    title: 'Junk Journal Workshop',
+    start: '2025-03-15T12:00:00',
+    end: '2025-03-15T16:00:00',
+    location: 'Artworks Gallery, 210 N Main St',
+    description:
+      'Create a handmade journal using recycled materials. Instructor: Vivian Bennett. Fee: $62.50 including materials. Limited seats available.'
+  },
+  {
+    id: 'photo-show',
+    title: '2025 Photo Show',
+    start: '2025-03-05',
+    end: '2025-03-29',
+    allDay: true,
+    location: 'Kokomo Art Center, 525 W Ricketts St',
+    description:
+      'Community photography exhibition showcasing the talent of local photographers.'
+  },
+  {
+    id: 'circus-exhibit',
+    title: 'Circus Is Coming to Town',
+    start: '2025-05-02',
+    end: '2025-06-27',
+    allDay: true,
+    location: 'Kokomo Art Center, 525 W Ricketts St',
+    description:
+      'Partnership exhibition with the International Circus Museum featuring circus-themed artworks and silent auction items.'
+  }
+];
+
+function formatICSDate(date) {
+  return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+function generateICS(event) {
+  const start = formatICSDate(new Date(event.start));
+  const end = formatICSDate(event.end ? new Date(event.end) : new Date(event.start));
+  const description = (event.description || '').replace(/\n/g, '\\n');
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'BEGIN:VEVENT',
+    `SUMMARY:${event.title}`,
+    `DESCRIPTION:${description}`,
+    `LOCATION:${event.location || ''}`,
+    `DTSTART:${start}`,
+    `DTEND:${end}`,
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\n');
+}
+
+function generateGoogleCalendarLink(event) {
+  const start = formatICSDate(new Date(event.start));
+  const end = formatICSDate(event.end ? new Date(event.end) : new Date(event.start));
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${start}/${end}`,
+    details: event.description || '',
+    location: event.location || '',
+    sf: 'true',
+    output: 'xml'
+  });
+  return `https://www.google.com/calendar/render?${params.toString()}`;
+}
+
+function addCalendarLinks(eventInfo) {
+  const eventData = eventsCalendarData.find(e => e.title === eventInfo.title);
+  if (!eventData) return '';
+  const googleUrl = generateGoogleCalendarLink(eventData);
+  const icsData = generateICS(eventData);
+  const icsHref = `data:text/calendar;charset=utf8,${encodeURIComponent(icsData)}`;
+  return `<div class="calendar-links">Add to calendar: <a href="${googleUrl}" target="_blank" rel="noopener" class="btn btn--sm btn--primary">Google</a> <a href="${icsHref}" download="event.ics" class="btn btn--sm btn--outline">ICS</a></div>`;
+}
+
 // DOM elements
 let hamburger, navOverlay, navClose, modal, modalClose, modalTitle, modalBody, navContent;
+let eventsViewBtn, calendarViewBtn, eventsGrid, eventsCalendar;
 let lastFocusedElement = null;
 let isScrolling = false;
 let navScrollTimeout = null;
@@ -256,6 +430,10 @@ function initializeElements() {
   modalTitle = document.getElementById('modalTitle');
   modalBody = document.getElementById('modalBody');
   navContent = navOverlay ? navOverlay.querySelector('.nav-overlay-content') : null;
+  eventsViewBtn = document.getElementById('eventsViewBtn');
+  calendarViewBtn = document.getElementById('calendarViewBtn');
+  eventsGrid = document.getElementById('eventsGrid');
+  eventsCalendar = document.getElementById('eventsCalendar');
   
   console.log('📋 Element status:', {
     hamburger: hamburger ? '✅' : '❌',
@@ -265,7 +443,11 @@ function initializeElements() {
     modalClose: modalClose ? '✅' : '❌',
     modalTitle: modalTitle ? '✅' : '❌',
     modalBody: modalBody ? '✅' : '❌',
-    navContent: navContent ? '✅' : '❌'
+    navContent: navContent ? '✅' : '❌',
+    eventsViewBtn: eventsViewBtn ? '✅' : '❌',
+    calendarViewBtn: calendarViewBtn ? '✅' : '❌',
+    eventsGrid: eventsGrid ? '✅' : '❌',
+    eventsCalendar: eventsCalendar ? '✅' : '❌'
   });
   
   // Ensure modal is hidden initially
@@ -437,6 +619,7 @@ function populateContent() {
     populateClasses();
     populateMembership();
     populateEvents();
+    initializeEventsToggle();
     populateSponsors();
     console.log('✅ All content populated successfully');
   } catch (error) {
@@ -647,12 +830,42 @@ function populateEvents() {
         <p>${event.description}</p>
         ${event.details ? `<p style="font-size: var(--font-size-sm); color: var(--color-text-secondary); margin-top: var(--space-8);">${event.details}</p>` : ''}
         <a href="mailto:${appData.contact.email}?subject=Event%20Information%20-%20${encodeURIComponent(event.title)}" class="btn btn--outline mt-8">Learn More</a>
+        ${addCalendarLinks(event)}
       </div>
     `;
     eventsGrid.appendChild(eventCard);
   });
   
   console.log('✅ Events populated');
+}
+
+function initializeEventsToggle() {
+  if (!eventsViewBtn || !calendarViewBtn || !eventsGrid || !eventsCalendar) {
+    return;
+  }
+
+  eventsViewBtn.addEventListener('click', function(e) {
+    e.preventDefault();
+    eventsViewBtn.classList.add('btn--primary', 'active');
+    eventsViewBtn.classList.remove('btn--outline');
+    calendarViewBtn.classList.remove('btn--primary', 'active');
+    calendarViewBtn.classList.add('btn--outline');
+    eventsGrid.classList.remove('hidden');
+    eventsCalendar.classList.add('hidden');
+  });
+
+  calendarViewBtn.addEventListener('click', function(e) {
+    e.preventDefault();
+    calendarViewBtn.classList.add('btn--primary', 'active');
+    calendarViewBtn.classList.remove('btn--outline');
+    eventsViewBtn.classList.remove('btn--primary', 'active');
+    eventsViewBtn.classList.add('btn--outline');
+    eventsGrid.classList.add('hidden');
+    eventsCalendar.classList.remove('hidden');
+  });
+
+  // Default to events view
+  eventsViewBtn.click();
 }
 
 // Populate sponsors

--- a/calendar/app.js
+++ b/calendar/app.js
@@ -127,7 +127,7 @@ const eventsData = [
 
 // Global variables
 let calendar;
-let currentView = 'month';
+let currentView = 'list';
 let filteredEvents = [...eventsData];
 
 // DOM elements
@@ -152,6 +152,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeEventFilter();
     initializeKeyboardNavigation();
     populateListView();
+    switchToListView();
     
     // Hide loading overlay after short delay to allow calendar render
     setTimeout(() => {

--- a/calendar/style.css
+++ b/calendar/style.css
@@ -881,6 +881,7 @@ h6 { font-size: var(--font-size-md); }
   align-items: center;
 }
 
+
 /* Buttons */
 .btn {
   display: inline-flex;

--- a/index.html
+++ b/index.html
@@ -50,13 +50,6 @@
       </div>
     </section>
 
-    <!-- Calendar Section -->
-    <section id="calendar" class="section fade-section">
-      <div class="container">
-        <h2 class="section-title">Calendar</h2>
-        <iframe src="/calendar/index.html" width="100%" height="800" loading="lazy"></iframe>
-      </div>
-    </section>
 
     <!-- About Section -->
     <section id="about" class="section fade-section">
@@ -144,10 +137,14 @@
     <section id="events" class="section fade-section">
       <div class="container">
         <h2 class="section-title">Upcoming Events</h2>
+        <div class="view-toggle">
+          <button id="eventsViewBtn" class="btn btn--primary">Events</button>
+          <button id="calendarViewBtn" class="btn btn--outline">Calendar</button>
+        </div>
         <div class="events-grid" id="eventsGrid">
           <!-- Events will be populated by JavaScript -->
         </div>
-        <iframe src="/calendar/index.html" width="100%" height="800" loading="lazy"></iframe>
+        <iframe id="eventsCalendar" src="/calendar/index.html" width="100%" height="800" loading="lazy" class="hidden"></iframe>
       </div>
     </section>
 
@@ -202,15 +199,16 @@
                 <div><h4 class="font-bold text-lg mb-4 text-gray-900">Join Our Newsletter</h4><form onsubmit="return false;"><div class="flex"><input type="email" class="w-full rounded-l-md px-3 py-2 border border-gray-300 text-gray-800" placeholder="your.email@example.com"><button type="submit" class="bg-teal-600 text-white px-4 py-2 rounded-r-md hover:bg-teal-700">&rarr;</button></div></form><div class="flex space-x-4 mt-4"><a href="https://www.facebook.com/KokomoArtAssociation/?fref=ts" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-facebook-square"></i></a><a href="https://www.instagram.com/kokomoartassociation/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-instagram-square"></i></a></div></div>
             </div>
             <div class="footer-sponsor-section">
-                <h4 class="font-bold text-lg mb-6 text-center text-gray-700">Our Valued Sponsors</h4>
-                <div class="flex flex-wrap justify-center items-center gap-8 footer-sponsors">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
+                <div class="container sponsor-container">
+                    <div class="flex flex-wrap justify-center items-center gap-8 footer-sponsors">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
+                    </div>
                 </div>
             </div>
             <div class="border-t border-gray-200 mt-8 pt-6 text-center text-gray-600"><p>&copy; <span id="year"></span> Kokomo Art Association. All Rights Reserved.</p></div>

--- a/style.css
+++ b/style.css
@@ -169,6 +169,26 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.view-toggle {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-8);
+  margin-top: var(--space-16);
+}
+
+.calendar-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-8);
+  margin-top: var(--space-16);
+}
+
+.calendar-links a {
+  font-size: var(--font-size-sm);
+}
+
+
+
 @media (max-width: 640px) {
   .footer-sponsors img {
     max-width: 90px;


### PR DESCRIPTION
## Summary
- add view toggle between card list and calendar in Events section
- include "Add to calendar" options on each event card
- style new calendar links and controls
- store calendar event metadata in app.js

## Testing
- `node --check app.js`
- `node --check calendar/app.js`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687bebf5e83083289eb58778144bd67a