### PR TITLE
Add calendar overlay and external link

### DIFF
--- a/app.js
+++ b/app.js
@@ -213,8 +213,180 @@ const appData = {
   ]
 };
 
+// Structured event data for calendar links
+const eventsCalendarData = [
+  {
+    id: 'splash-watercolor',
+    title: 'Splash of Watercolor Exhibit',
+    start: '2025-07-01',
+    end: '2025-07-30',
+    allDay: true,
+    location: 'Kokomo Art Center, 525 W Ricketts St',
+    description:
+      'Delicately beautiful watercolor artworks by Jennie Moore, Judy Arthur, Cissie Seidman, and Dixie Bennett.'
+  },
+  {
+    id: 'guest-artist-bass',
+    title: 'Guest Artist Reception: Brandon C. Bass',
+    start: '2025-07-12T12:00:00',
+    end: '2025-07-12T15:00:00',
+    location: 'Artworks Gallery, 210 N Main St',
+    description:
+      'Free reception featuring portraits, military subjects, pets & landscapes by Brandon C. Bass. Light refreshments provided.'
+  },
+  {
+    id: 'first-friday-aug',
+    title: "First Friday 'Get Schooled!'",
+    start: '2025-08-01T17:30:00',
+    end: '2025-08-01T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Back-to-school themed art demos and activities. KAA hosts open house in Artworks Gallery.'
+  },
+  {
+    id: 'first-friday-sep',
+    title: "First Friday 'Art Walk'",
+    start: '2025-09-05T17:30:00',
+    end: '2025-09-05T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Monthly arts-driven street festival with gallery programming and community art activities.'
+  },
+  {
+    id: 'first-friday-oct',
+    title: "First Friday 'Masquerade'",
+    start: '2025-10-03T17:30:00',
+    end: '2025-10-03T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Halloween-themed First Friday with masquerade activities and special gallery exhibitions.'
+  },
+  {
+    id: 'first-friday-nov',
+    title: "First Friday 'Shop & Stroll'",
+    start: '2025-11-07T17:30:00',
+    end: '2025-11-07T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Holiday shopping-themed First Friday with local artists showcasing gift-worthy works.'
+  },
+  {
+    id: 'holiday-bazaar',
+    title: 'Holiday Bazaar',
+    start: '2025-11-01',
+    end: '2025-12-23',
+    allDay: true,
+    location: 'Artworks Gallery, 210 N Main St',
+    description:
+      'Extended holiday market featuring local artists and craftspeople. Open Mon-Sat 12-4 PM with extended hours on First Fridays.'
+  },
+  {
+    id: 'first-friday-dec',
+    title: "First Friday 'Ugly Sweater'",
+    start: '2025-12-05T17:30:00',
+    end: '2025-12-05T20:00:00',
+    location: 'Downtown Kokomo',
+    description:
+      'Holiday-themed First Friday with ugly sweater contest and festive art activities.'
+  },
+  {
+    id: 'spring-art-show',
+    title: '97th Annual Spring Art Show',
+    start: '2025-05-22',
+    end: '2025-06-01',
+    allDay: true,
+    location: 'Kokomo Art Center, 525 W Ricketts St',
+    description:
+      'Annual juried showcase featuring the best of local and regional artists. Closing reception June 1 at 2 PM.'
+  },
+  {
+    id: 'recycled-art-show',
+    title: 'Recycled Art Show',
+    start: '2025-03-07',
+    end: '2025-04-25',
+    allDay: true,
+    location: 'Artworks Gallery, 210 N Main St',
+    description:
+      'Juried exhibition featuring works created with 80% or more recycled materials. Awards reception April 4.'
+  },
+  {
+    id: 'junk-journal-workshop',
+    title: 'Junk Journal Workshop',
+    start: '2025-03-15T12:00:00',
+    end: '2025-03-15T16:00:00',
+    location: 'Artworks Gallery, 210 N Main St',
+    description:
+      'Create a handmade journal using recycled materials. Instructor: Vivian Bennett. Fee: $62.50 including materials. Limited seats available.'
+  },
+  {
+    id: 'photo-show',
+    title: '2025 Photo Show',
+    start: '2025-03-05',
+    end: '2025-03-29',
+    allDay: true,
+    location: 'Kokomo Art Center, 525 W Ricketts St',
+    description:
+      'Community photography exhibition showcasing the talent of local photographers.'
+  },
+  {
+    id: 'circus-exhibit',
+    title: 'Circus Is Coming to Town',
+    start: '2025-05-02',
+    end: '2025-06-27',
+    allDay: true,
+    location: 'Kokomo Art Center, 525 W Ricketts St',
+    description:
+      'Partnership exhibition with the International Circus Museum featuring circus-themed artworks and silent auction items.'
+  }
+];
+
+function formatICSDate(date) {
+  return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+function generateICS(event) {
+  const start = formatICSDate(new Date(event.start));
+  const end = formatICSDate(event.end ? new Date(event.end) : new Date(event.start));
+  const description = (event.description || '').replace(/\n/g, '\\n');
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'BEGIN:VEVENT',
+    `SUMMARY:${event.title}`,
+    `DESCRIPTION:${description}`,
+    `LOCATION:${event.location || ''}`,
+    `DTSTART:${start}`,
+    `DTEND:${end}`,
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\n');
+}
+
+function generateGoogleCalendarLink(event) {
+  const start = formatICSDate(new Date(event.start));
+  const end = formatICSDate(event.end ? new Date(event.end) : new Date(event.start));
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${start}/${end}`,
+    details: event.description || '',
+    location: event.location || '',
+    sf: 'true',
+    output: 'xml'
+  });
+  return `https://www.google.com/calendar/render?${params.toString()}`;
+}
+
+function addCalendarLink(eventInfo) {
+  const eventData = eventsCalendarData.find(e => e.title === eventInfo.title);
+  if (!eventData) return '';
+  return `<div class="calendar-add"><a href="#" class="add-to-calendar" data-event-id="${eventData.id}">+ add to calendar</a></div>`;
+}
+
 // DOM elements
 let hamburger, navOverlay, navClose, modal, modalClose, modalTitle, modalBody, navContent;
+let eventsGrid;
+let calendarModal, calendarModalClose, calendarModalLinks;
 let lastFocusedElement = null;
 let isScrolling = false;
 let navScrollTimeout = null;
@@ -256,6 +428,10 @@ function initializeElements() {
   modalTitle = document.getElementById('modalTitle');
   modalBody = document.getElementById('modalBody');
   navContent = navOverlay ? navOverlay.querySelector('.nav-overlay-content') : null;
+  eventsGrid = document.getElementById('eventsGrid');
+  calendarModal = document.getElementById('calendarModal');
+  calendarModalClose = document.getElementById('calendarModalClose');
+  calendarModalLinks = document.getElementById('calendarModalLinks');
   
   console.log('📋 Element status:', {
     hamburger: hamburger ? '✅' : '❌',
@@ -265,7 +441,9 @@ function initializeElements() {
     modalClose: modalClose ? '✅' : '❌',
     modalTitle: modalTitle ? '✅' : '❌',
     modalBody: modalBody ? '✅' : '❌',
-    navContent: navContent ? '✅' : '❌'
+    navContent: navContent ? '✅' : '❌',
+    eventsGrid: eventsGrid ? '✅' : '❌',
+    calendarModal: calendarModal ? '✅' : '❌'
   });
   
   // Ensure modal is hidden initially
@@ -273,6 +451,11 @@ function initializeElements() {
     modal.setAttribute('hidden', '');
     modal.setAttribute('aria-hidden', 'true');
     modal.style.display = 'none';
+  }
+  if (calendarModal) {
+    calendarModal.setAttribute('hidden', '');
+    calendarModal.setAttribute('aria-hidden', 'true');
+    calendarModal.style.display = 'none';
   }
 }
 
@@ -437,6 +620,7 @@ function populateContent() {
     populateClasses();
     populateMembership();
     populateEvents();
+    initializeAddToCalendar();
     populateSponsors();
     console.log('✅ All content populated successfully');
   } catch (error) {
@@ -647,6 +831,7 @@ function populateEvents() {
         <p>${event.description}</p>
         ${event.details ? `<p style="font-size: var(--font-size-sm); color: var(--color-text-secondary); margin-top: var(--space-8);">${event.details}</p>` : ''}
         <a href="mailto:${appData.contact.email}?subject=Event%20Information%20-%20${encodeURIComponent(event.title)}" class="btn btn--outline mt-8">Learn More</a>
+        ${addCalendarLink(event)}
       </div>
     `;
     eventsGrid.appendChild(eventCard);
@@ -654,6 +839,7 @@ function populateEvents() {
   
   console.log('✅ Events populated');
 }
+
 
 // Populate sponsors
 function populateSponsors() {
@@ -687,7 +873,7 @@ function populateSponsors() {
 // Modal functionality with error checking
 function initializeModal() {
   console.log('🪟 Initializing modal...');
-  
+
   if (!modal || !modalClose) {
     console.error('❌ Modal elements not found - modal functionality disabled');
     return;
@@ -706,7 +892,21 @@ function initializeModal() {
       closeArtistModal();
     }
   });
-  
+
+  if (calendarModal && calendarModalClose) {
+    calendarModalClose.addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      closeCalendarModal();
+    });
+
+    calendarModal.addEventListener('click', function(e) {
+      if (e.target === calendarModal) {
+        closeCalendarModal();
+      }
+    });
+  }
+
   console.log('✅ Modal initialized');
 }
 
@@ -769,6 +969,57 @@ function closeArtistModal() {
   }
   
   console.log('✅ Artist modal closed');
+}
+
+// Calendar modal functionality
+function openCalendarModal(eventId) {
+  const eventData = eventsCalendarData.find(e => e.id === eventId);
+  if (!calendarModal || !calendarModalLinks || !eventData) {
+    console.error('❌ Unable to open calendar modal');
+    return;
+  }
+
+  const googleUrl = generateGoogleCalendarLink(eventData);
+  const icsData = generateICS(eventData);
+  const icsHref = `data:text/calendar;charset=utf8,${encodeURIComponent(icsData)}`;
+
+  calendarModalLinks.innerHTML = `
+    <a href="${icsHref}" download="${eventData.id}.ics" class="btn btn--primary">Apple</a>
+    <a href="${googleUrl}" target="_blank" rel="noopener" class="btn btn--outline">Google</a>
+    <a href="${icsHref}" download="${eventData.id}.ics" class="btn btn--outline">Outlook</a>
+  `;
+
+  lastFocusedElement = document.activeElement;
+  calendarModal.removeAttribute('hidden');
+  calendarModal.setAttribute('aria-hidden', 'false');
+  calendarModal.style.display = 'flex';
+  document.body.style.overflow = 'hidden';
+
+  setTimeout(() => {
+    if (calendarModalClose) calendarModalClose.focus();
+  }, 100);
+}
+
+function closeCalendarModal() {
+  if (!calendarModal) return;
+  calendarModal.setAttribute('hidden', '');
+  calendarModal.setAttribute('aria-hidden', 'true');
+  calendarModal.style.display = 'none';
+  document.body.style.overflow = 'auto';
+  if (lastFocusedElement) {
+    lastFocusedElement.focus();
+    lastFocusedElement = null;
+  }
+}
+
+function initializeAddToCalendar() {
+  document.querySelectorAll('.add-to-calendar').forEach(link => {
+    link.addEventListener('click', function(e) {
+      e.preventDefault();
+      const eventId = this.getAttribute('data-event-id');
+      openCalendarModal(eventId);
+    });
+  });
 }
 
 // Accordion functionality - now handled directly in populateClasses

--- a/calendar/app.js
+++ b/calendar/app.js
@@ -127,7 +127,7 @@ const eventsData = [
 
 // Global variables
 let calendar;
-let currentView = 'month';
+let currentView = 'list';
 let filteredEvents = [...eventsData];
 
 // DOM elements
@@ -152,6 +152,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeEventFilter();
     initializeKeyboardNavigation();
     populateListView();
+    switchToListView();
     
     // Hide loading overlay after short delay to allow calendar render
     setTimeout(() => {

--- a/calendar/style.css
+++ b/calendar/style.css
@@ -881,6 +881,7 @@ h6 { font-size: var(--font-size-md); }
   align-items: center;
 }
 
+
 /* Buttons */
 .btn {
   display: inline-flex;

--- a/index.html
+++ b/index.html
@@ -50,13 +50,6 @@
       </div>
     </section>
 
-    <!-- Calendar Section -->
-    <section id="calendar" class="section fade-section">
-      <div class="container">
-        <h2 class="section-title">Calendar</h2>
-        <iframe src="/calendar/index.html" width="100%" height="800" loading="lazy"></iframe>
-      </div>
-    </section>
 
     <!-- About Section -->
     <section id="about" class="section fade-section">
@@ -147,7 +140,9 @@
         <div class="events-grid" id="eventsGrid">
           <!-- Events will be populated by JavaScript -->
         </div>
-        <iframe src="/calendar/index.html" width="100%" height="800" loading="lazy"></iframe>
+        <div class="calendar-link">
+          <a href="calendar/index.html" class="btn btn--outline" target="_blank" rel="noopener">View Full Calendar</a>
+        </div>
       </div>
     </section>
 
@@ -192,6 +187,14 @@
     </div>
   </div>
 
+  <div class="modal" id="calendarModal" aria-hidden="true" hidden>
+    <div class="modal-content">
+      <button class="modal-close btn btn--outline" id="calendarModalClose" aria-label="Close modal">&times;</button>
+      <h3 class="modal-title">Add to Calendar</h3>
+      <div class="calendar-links" id="calendarModalLinks"></div>
+    </div>
+  </div>
+
   <script src="app.js"></script>
 </body>
     <footer id="footer" class="bg-white text-gray-800 border-t">
@@ -202,15 +205,16 @@
                 <div><h4 class="font-bold text-lg mb-4 text-gray-900">Join Our Newsletter</h4><form onsubmit="return false;"><div class="flex"><input type="email" class="w-full rounded-l-md px-3 py-2 border border-gray-300 text-gray-800" placeholder="your.email@example.com"><button type="submit" class="bg-teal-600 text-white px-4 py-2 rounded-r-md hover:bg-teal-700">&rarr;</button></div></form><div class="flex space-x-4 mt-4"><a href="https://www.facebook.com/KokomoArtAssociation/?fref=ts" target="_blank" rel="noopener noreferrer" aria-label="Facebook" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-facebook-square"></i></a><a href="https://www.instagram.com/kokomoartassociation/" target="_blank" rel="noopener noreferrer" aria-label="Instagram" class="text-2xl text-gray-500 hover:text-teal-600"><i class="fab fa-instagram-square"></i></a></div></div>
             </div>
             <div class="footer-sponsor-section">
-                <h4 class="font-bold text-lg mb-6 text-center text-gray-700">Our Valued Sponsors</h4>
-                <div class="flex flex-wrap justify-center items-center gap-8 footer-sponsors">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
-                    <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
+                <div class="container sponsor-container">
+                    <div class="flex flex-wrap justify-center items-center gap-8 footer-sponsors">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/dukeenergy.png" alt="Duke Energy Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Howard%20County%20logos_Page_01.png" alt="Howard County Logo" class="h-20 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/tri-countyScmyk_newblue_gwp_071620_stacked.png" alt="Tri-County Logo" class="h-20 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/IAC_Logo_Horizontal.png" alt="Indiana Arts Commission Logo" class="h-12 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/2018-Horizontal-Logo-with-url-thumb_0.png" alt="National Endowment for the Arts Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/Logo_AM_Horizontal_Black.png" alt="Arts Midwest Logo" class="h-14 w-auto">
+                        <img src="https://raw.githubusercontent.com/Kmberry1989/kaaonline/main/blick.png" alt="Blick Art Materials Logo" class="h-10 w-auto">
+                    </div>
                 </div>
             </div>
             <div class="border-t border-gray-200 mt-8 pt-6 text-center text-gray-600"><p>&copy; <span id="year"></span> Kokomo Art Association. All Rights Reserved.</p></div>

--- a/style.css
+++ b/style.css
@@ -169,6 +169,35 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.calendar-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-8);
+  margin-top: var(--space-16);
+}
+
+.calendar-links a {
+  font-size: var(--font-size-sm);
+}
+
+.calendar-link {
+  text-align: right;
+  margin-top: var(--space-24);
+}
+
+.calendar-add {
+  margin-top: var(--space-16);
+}
+
+.add-to-calendar {
+  font-size: var(--font-size-sm);
+  color: var(--color-primary);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+
+
 @media (max-width: 640px) {
   .footer-sponsors img {
     max-width: 90px;


### PR DESCRIPTION
## Summary
- remove embedded calendar and view toggle
- provide link to standalone calendar page
- add overlay to pick Apple, Google, or Outlook when adding events to a calendar
- style new calendar controls

## Testing
- `node --check app.js`
- `node --check calendar/app.js`
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687bebf5e83083289eb58778144bd67a